### PR TITLE
Don't install Passenger from RubyGems

### DIFF
--- a/decidim-bionic.md
+++ b/decidim-bionic.md
@@ -228,7 +228,6 @@ Add at the end of the `Gemfile`:
 
 ```ruby
 group :production do
-  gem "passenger"
   gem 'delayed_job_active_record'
   gem "daemons"
 end


### PR DESCRIPTION
Since Passenger is installed from Apt repository, second Passenger installed from RubyGems is redundant and can cause conflicts later: https://github.com/Platoniq/decidim-install/issues/14